### PR TITLE
Add like/unlike feature for posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A simple blog application built with Spring Boot.
 - Create, edit, delete, and view blog posts
 - Comment on blog posts
 - View user profiles
+- Like and unlike posts
 
 ## Technologies Used
 

--- a/src/main/java/com/sandeep/blog/blogapplication/controller/PostController.java
+++ b/src/main/java/com/sandeep/blog/blogapplication/controller/PostController.java
@@ -56,4 +56,14 @@ public class PostController {
         return postService.deletePost(id);
     }
 
+    @PostMapping("/{id}/like")
+    public ResponseEntity<Post> likePost(@PathVariable long id){
+        return postService.likePost(id);
+    }
+
+    @DeleteMapping("/{id}/like")
+    public ResponseEntity<Post> unlikePost(@PathVariable long id){
+        return postService.unlikePost(id);
+    }
+
 }

--- a/src/main/java/com/sandeep/blog/blogapplication/model/Post.java
+++ b/src/main/java/com/sandeep/blog/blogapplication/model/Post.java
@@ -41,7 +41,11 @@ public class Post {
     )
     private Set<Tag> tags = new HashSet<>();
 
+    @Column(nullable = false)
+    private int likes = 0;
+
     //using PrePersist and PreUpdate to automatically set timestamps
+    @PrePersist
     protected void onCreate(){
         createDate = LocalDateTime.now();
         updateDate = LocalDateTime.now();

--- a/src/main/java/com/sandeep/blog/blogapplication/service/PostService.java
+++ b/src/main/java/com/sandeep/blog/blogapplication/service/PostService.java
@@ -108,4 +108,38 @@ public class PostService {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
+
+    public ResponseEntity<Post> likePost(long id) {
+        try {
+            Optional<Post> optionalPost = postRepository.findById(id);
+            if(optionalPost.isPresent()){
+                Post post = optionalPost.get();
+                post.setLikes(post.getLikes() + 1);
+                postRepository.save(post);
+                return new ResponseEntity<>(post, HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            }
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public ResponseEntity<Post> unlikePost(long id) {
+        try {
+            Optional<Post> optionalPost = postRepository.findById(id);
+            if(optionalPost.isPresent()){
+                Post post = optionalPost.get();
+                if(post.getLikes() > 0){
+                    post.setLikes(post.getLikes() - 1);
+                    postRepository.save(post);
+                }
+                return new ResponseEntity<>(post, HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            }
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- document ability to like and unlike posts
- allow liking and unliking posts via REST endpoints

## Testing
- `./mvnw -q test` *(fails: network access needed to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_684c7a14ef64832fa6d992b1ad201ab9