### PR TITLE
Add simple React frontend and CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ A simple blog application built with Spring Boot.
 - Create, edit, delete, and view blog posts
 - Comment on blog posts
 - View user profiles
+- Like and unlike posts
+- View top liked posts
+- Obtain JWT tokens via `/auth/login` for stateless authentication
+- Simple React UI for viewing posts
 
 ## Technologies Used
 
@@ -17,6 +21,7 @@ A simple blog application built with Spring Boot.
 - MySQL database
 - MySQL (for production)
 - Spring Security
+- React (frontend)
 
 ## Getting Started
 
@@ -32,3 +37,16 @@ A simple blog application built with Spring Boot.
    ```sh
    git clone https://github.com/username/blog-application.git
    cd blog-application
+   ```
+
+2. Set the `JWT_SECRET` environment variable for token generation (optional):
+   ```sh
+   export JWT_SECRET=yourStrongSecret
+   ```
+
+3. Start the React frontend (optional):
+   ```sh
+   cd frontend
+   python -m http.server 3000
+   ```
+   Then open [http://localhost:3000/index.html](http://localhost:3000/index.html) in your browser.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,13 @@
+# Blog Frontend
+
+This is a simple React-based interface for the Blog Application backend. It uses CDN-hosted React so no build tools are required.
+
+## Running
+
+Serve the `frontend` directory using any static file server. For example:
+
+```sh
+python -m http.server 3000
+```
+
+Then open [http://localhost:3000/index.html](http://localhost:3000/index.html) in your browser. The page fetches posts from `http://localhost:8080` by default.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,25 @@
+const { useState, useEffect } = React;
+
+function App() {
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:8080/post/getAllPost')
+      .then(res => res.json())
+      .then(setPosts)
+      .catch(err => console.error('Failed to load posts', err));
+  }, []);
+
+  return (
+    <div>
+      <h1>Blog Posts</h1>
+      <ul>
+        {posts.map(post => (
+          <li key={post.id}>{post.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blog Application</title>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/src/main/java/com/sandeep/blog/blogapplication/config/CorsConfig.java
+++ b/src/main/java/com/sandeep/blog/blogapplication/config/CorsConfig.java
@@ -1,0 +1,22 @@
+package com.sandeep.blog.blogapplication.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:3000")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE")
+                        .allowedHeaders("*");
+            }
+        };
+    }
+}

--- a/src/main/java/com/sandeep/blog/blogapplication/controller/AuthController.java
+++ b/src/main/java/com/sandeep/blog/blogapplication/controller/AuthController.java
@@ -1,0 +1,52 @@
+package com.sandeep.blog.blogapplication.controller;
+
+import com.sandeep.blog.blogapplication.jwt.JwtUtils;
+import com.sandeep.blog.blogapplication.payload.LoginRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private static final Logger logger = LoggerFactory.getLogger(AuthController.class);
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    private JwtUtils jwtUtils;
+
+    @PostMapping("/login")
+    public ResponseEntity<Map<String, String>> login(@RequestBody LoginRequest request) {
+        try {
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword()));
+            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+            String token = jwtUtils.generateTokenFromUsername(userDetails);
+            Map<String, String> body = new HashMap<>();
+            body.put("token", token);
+            return ResponseEntity.ok(body);
+        } catch (AuthenticationException e) {
+            logger.warn("Login failed for user {}: {}", request.getUsername(), e.getMessage());
+            Map<String, String> error = new HashMap<>();
+            error.put("error", "Invalid username or password");
+            return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/sandeep/blog/blogapplication/controller/PostController.java
+++ b/src/main/java/com/sandeep/blog/blogapplication/controller/PostController.java
@@ -41,6 +41,11 @@ public class PostController {
         return postService.getPostByUser(userId);
     }
 
+    @GetMapping("/top/{count}")
+    public ResponseEntity<List<Post>> getTopPosts(@PathVariable int count) {
+        return postService.getTopPosts(count);
+    }
+
     @PostMapping("/addPost")
     public ResponseEntity<Post> addPost(@RequestBody Post post){
         return postService.addPost(post);
@@ -54,6 +59,16 @@ public class PostController {
     @DeleteMapping("/deletePost/{id}")
     public ResponseEntity<Post> deletePost(@PathVariable long id){
         return postService.deletePost(id);
+    }
+
+    @PostMapping("/{id}/like")
+    public ResponseEntity<Post> likePost(@PathVariable long id){
+        return postService.likePost(id);
+    }
+
+    @DeleteMapping("/{id}/like")
+    public ResponseEntity<Post> unlikePost(@PathVariable long id){
+        return postService.unlikePost(id);
     }
 
 }

--- a/src/main/java/com/sandeep/blog/blogapplication/jwt/JwtUtils.java
+++ b/src/main/java/com/sandeep/blog/blogapplication/jwt/JwtUtils.java
@@ -61,7 +61,7 @@ public class JwtUtils {
 
     public boolean validateToken(String authToken) {
         try {
-            System.out.println("Validate");
+            logger.debug("Validating JWT token");
             Jwts.parser()
                     .verifyWith((SecretKey) key())
                     .build()

--- a/src/main/java/com/sandeep/blog/blogapplication/model/Post.java
+++ b/src/main/java/com/sandeep/blog/blogapplication/model/Post.java
@@ -41,7 +41,11 @@ public class Post {
     )
     private Set<Tag> tags = new HashSet<>();
 
+    @Column(nullable = false)
+    private int likes = 0;
+
     //using PrePersist and PreUpdate to automatically set timestamps
+    @PrePersist
     protected void onCreate(){
         createDate = LocalDateTime.now();
         updateDate = LocalDateTime.now();

--- a/src/main/java/com/sandeep/blog/blogapplication/payload/LoginRequest.java
+++ b/src/main/java/com/sandeep/blog/blogapplication/payload/LoginRequest.java
@@ -1,0 +1,22 @@
+package com.sandeep.blog.blogapplication.payload;
+
+public class LoginRequest {
+    private String username;
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/sandeep/blog/blogapplication/service/PostService.java
+++ b/src/main/java/com/sandeep/blog/blogapplication/service/PostService.java
@@ -6,6 +6,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +19,8 @@ import java.util.Optional;
 public class PostService {
     @Autowired
     PostRepository postRepository;
+
+    private static final Logger logger = LoggerFactory.getLogger(PostService.class);
 
     public ResponseEntity<List<Post>> getAllPost() {
         try {
@@ -65,6 +72,17 @@ public class PostService {
         }
     }
 
+    public ResponseEntity<List<Post>> getTopPosts(int count) {
+        try {
+            Pageable pageable = PageRequest.of(0, count, Sort.by(Sort.Direction.DESC, "likes"));
+            List<Post> posts = postRepository.findAll(pageable).getContent();
+            return new ResponseEntity<>(posts, HttpStatus.OK);
+        } catch (Exception e) {
+            logger.error("Error retrieving top posts", e);
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
     public ResponseEntity<Post> addPost(Post post) {
         try {
             Post postToBeAdded = postRepository.save(post);
@@ -105,6 +123,40 @@ public class PostService {
                 return new ResponseEntity<>(HttpStatus.NOT_FOUND);
             }
         }catch (Exception e){
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public ResponseEntity<Post> likePost(long id) {
+        try {
+            Optional<Post> optionalPost = postRepository.findById(id);
+            if(optionalPost.isPresent()){
+                Post post = optionalPost.get();
+                post.setLikes(post.getLikes() + 1);
+                postRepository.save(post);
+                return new ResponseEntity<>(post, HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            }
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public ResponseEntity<Post> unlikePost(long id) {
+        try {
+            Optional<Post> optionalPost = postRepository.findById(id);
+            if(optionalPost.isPresent()){
+                Post post = optionalPost.get();
+                if(post.getLikes() > 0){
+                    post.setLikes(post.getLikes() - 1);
+                    postRepository.save(post);
+                }
+                return new ResponseEntity<>(post, HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            }
+        } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,7 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL8Dialect
 #spring.security.user.name=user
 #spring.security.user.password=user
 
-spring.app.jwtSecret=mySecretKey123deadvillaseptember1997
+spring.app.jwtSecret=${JWT_SECRET:mySecretKey123deadvillaseptember1997}
 spring.app.jwtExpirationMs=86400000
 
 


### PR DESCRIPTION
## Summary
- let the backend accept requests from localhost:3000 with a `CorsConfig`
- add a minimal React UI under `frontend` to list posts
- document the new frontend in the README

## Testing
- `./mvnw -q test` *(fails: Permission denied)*
- `mvn -q test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7a14ef64832fa6d992b1ad201ab9