### PR TITLE
Add Swagger API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,13 @@ A simple blog application built with Spring Boot.
    python -m http.server 3000
    ```
    Then open [http://localhost:3000/index.html](http://localhost:3000/index.html) in your browser.
+
+### API Documentation
+
+After starting the Spring Boot application, you can explore all REST endpoints interactively using Swagger UI. Visit:
+
+```
+http://localhost:8084/blogpostapplication/swagger-ui/index.html
+```
+
+The OpenAPI specification is also available at `/blogpostapplication/v3/api-docs` and can be used to generate client libraries.

--- a/pom.xml
+++ b/pom.xml
@@ -82,12 +82,17 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.5.0</version>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
## Summary
- integrate springdoc-openapi for Swagger UI
- document how to access the interactive API docs in README

## Testing
- `./mvnw -q -DskipTests package` *(fails: wget failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d9b5d9ef0832f9aa92c449507a592