### PR TITLE
Allow public Swagger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,13 @@ A simple blog application built with Spring Boot.
    python -m http.server 3000
    ```
    Then open [http://localhost:3000/index.html](http://localhost:3000/index.html) in your browser.
+
+### API Documentation
+
+After starting the Spring Boot application, you can explore all REST endpoints interactively using Swagger UI. Visit:
+
+```
+http://localhost:8084/blogpostapplication/swagger-ui.html
+```
+
+Swagger resources are publicly accessible, so no authentication is required to browse the docs. The generated OpenAPI specification is also available at `/blogpostapplication/v3/api-docs` and can be used to generate client libraries.

--- a/pom.xml
+++ b/pom.xml
@@ -82,12 +82,17 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.5.0</version>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/sandeep/blog/blogapplication/config/SpringConfig.java
+++ b/src/main/java/com/sandeep/blog/blogapplication/config/SpringConfig.java
@@ -33,8 +33,6 @@ public class SpringConfig {
     @Autowired
     DataSource dataSource;
 
-    @Autowired
-    private AuthTokenFilter authTokenFilter;
 
 
     // This is the configuration for the security of the application
@@ -44,14 +42,14 @@ public class SpringConfig {
 
     //@Bean - This annotation is used to define a bean in the application context
     @Bean
-    public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http, AuthTokenFilter authTokenFilter) throws Exception {
         // The http.authorizeRequests method is used to define the authorization rules for the application
         // The http.sessionManagement method is used to define the session management policy for the application
         // The http.httpBasic method is used to define the basic authentication for the application
         // The http.build method is used to build the security filter chain
         http.authorizeHttpRequests(authorizeRequests ->
                         authorizeRequests
-                                .requestMatchers("/auth/login", "/user/add").permitAll()
+                                .requestMatchers("/auth/login", "/user/add", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                                 .requestMatchers("/user/allusers", "/user/*").hasAnyRole("USER", "ADMIN")
                                 .requestMatchers("/user/update", "/user/removeuser/*").hasRole("ADMIN")
                                 .anyRequest().authenticated())


### PR DESCRIPTION
## Summary
- make Swagger UI and OpenAPI spec accessible without auth
- update README with new Swagger URL and note about public access
- fix circular dependency in SpringConfig so app starts

## Testing
- `./mvnw -q -DskipTests package` *(fails: wget failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d9b5d9ef0832f9aa92c449507a592