### PR TITLE
Update README paths and Swagger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,26 @@
 
 A simple blog application built with Spring Boot.
 
-## Features
+## Features ✨
 
-- User registration and login
-- Create, edit, delete, and view blog posts
-- Comment on blog posts
-- View user profiles
-- Like and unlike posts
-- View top liked posts
+### Backend
+- 🔐 **User registration and login**
+- 📝 **Create, edit, delete, and view blog posts**
+- 💬 **Comment on blog posts**
+- 👤 **View user profiles**
+- 👍 **Like and unlike posts**
+- 📈 **View top liked posts**
+- 📌 **Bookmark favorite posts**
+- 🔖 **View posts filtered by tag**
+- 🔍 **Search posts by title or content**
+- 🛡️ **Obtain JWT tokens** via `/auth/login` for stateless authentication
 
-- Bookmark favorite posts
-- View posts filtered by tag
-- Search posts by title or content
-- Obtain JWT tokens via `/auth/login` for stateless authentication
-- Interactive React UI for browsing and liking posts with tag filtering
+### Frontend
+- 🖥️ **Interactive React UI** for browsing and liking posts with tag filtering
+- ⭐ **View top liked posts** from the React UI
+- ✍️ **Create posts with Markdown** formatting in the React UI
 
-- View top liked posts from the React UI
-- Create posts with Markdown formatting in the React UI
+### API Endpoints
 - `/post/tag/{tag}` endpoint to filter posts by a specific tag
 - `/post/search?q=keyword` endpoint to search posts
 - `/post/{postId}/comments` endpoint to view or add comments on a post
@@ -46,8 +49,8 @@ A simple blog application built with Spring Boot.
 
 1. Clone the repository:
    ```sh
-   git clone https://github.com/username/blog-application.git
-   cd blog-application
+   git clone https://github.com/username/Blogpost.git
+   cd Blogpost
    ```
 
 2. Set the `JWT_SECRET` environment variable for token generation (optional):
@@ -67,21 +70,35 @@ A simple blog application built with Spring Boot.
    configuration differs, update the values in
    `src/main/resources/application.properties` accordingly.
 
+### Running the Application 🚀
+
+1. From the project root, start the Spring Boot backend:
+   ```sh
+   ./mvnw spring-boot:run
+   ```
+   The API will be available at [http://localhost:8084/blogpostapplication](http://localhost:8084/blogpostapplication).
+   The first run may take a while as Maven downloads dependencies.
+
+   If you want to prefetch all dependencies manually, run:
+   ```sh
+   ./mvnw dependency:resolve
+   ```
+   This command uses the [maven-dependency-plugin](https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-dependency-plugin) to ensure all required artifacts are downloaded.
+
+2. *(Optional)* Execute the test suite:
+   ```sh
+   ./mvnw test
+   ```
+
 
 ### API Documentation
 
 After starting the Spring Boot application, you can explore all REST endpoints interactively using Swagger UI. Visit:
 
 ```
-
-http://localhost:8084/blogpostapplication/swagger-ui.html
-```
-
-Swagger resources are publicly accessible, so no authentication is required to browse the docs. The generated OpenAPI specification is also available at `/blogpostapplication/v3/api-docs` and can be used to generate client libraries.
-
 http://localhost:8084/blogpostapplication/swagger-ui/index.html
 ```
 
-The OpenAPI specification is also available at `/blogpostapplication/v3/api-docs` and can be used to generate client libraries.
+Swagger resources are publicly accessible, so no authentication is required to browse the docs. The generated OpenAPI specification is also available at `/blogpostapplication/v3/api-docs` and can be used to generate client libraries.
 
 


### PR DESCRIPTION
## Summary
- fix repo directory name in Installation steps
- clean up Swagger UI link formatting

## Testing
- `npx -y babel frontend/app.js --out-file /tmp/app.out.js --presets=@babel/preset-react`
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6850009f05d0832fbfb995ae5ea25ec8