### PR TITLE
Switch backend to H2 database

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,26 @@
 
 A simple blog application built with Spring Boot.
 
-## Features
+## Features ✨
 
-- User registration and login
-- Create, edit, delete, and view blog posts
-- Comment on blog posts
-- View user profiles
-- Like and unlike posts
-- View top liked posts
+### Backend
+- 🔐 **User registration and login**
+- 📝 **Create, edit, delete, and view blog posts**
+- 💬 **Comment on blog posts**
+- 👤 **View user profiles**
+- 👍 **Like and unlike posts**
+- 📈 **View top liked posts**
+- 📌 **Bookmark favorite posts**
+- 🔖 **View posts filtered by tag**
+- 🔍 **Search posts by title or content**
+- 🛡️ **Obtain JWT tokens** via `/auth/login` for stateless authentication
 
-- Bookmark favorite posts
-- View posts filtered by tag
-- Search posts by title or content
-- Obtain JWT tokens via `/auth/login` for stateless authentication
-- Interactive React UI for browsing and liking posts with tag filtering
+### Frontend
+- 🖥️ **Interactive React UI** for browsing and liking posts with tag filtering
+- ⭐ **View top liked posts** from the React UI
+- ✍️ **Create posts with Markdown** formatting in the React UI
 
-- View top liked posts from the React UI
-- Create posts with Markdown formatting in the React UI
+### API Endpoints
 - `/post/tag/{tag}` endpoint to filter posts by a specific tag
 - `/post/search?q=keyword` endpoint to search posts
 - `/post/{postId}/comments` endpoint to view or add comments on a post
@@ -30,7 +33,7 @@ A simple blog application built with Spring Boot.
 - Spring Boot
 - Spring Data JPA
 - Thymeleaf
-- MySQL database
+- H2 in-memory database
 - Spring Security
 - React (frontend)
 
@@ -46,8 +49,8 @@ A simple blog application built with Spring Boot.
 
 1. Clone the repository:
    ```sh
-   git clone https://github.com/username/blog-application.git
-   cd blog-application
+   git clone https://github.com/username/Blogpost.git
+   cd Blogpost
    ```
 
 2. Set the `JWT_SECRET` environment variable for token generation (optional):
@@ -62,10 +65,30 @@ A simple blog application built with Spring Boot.
    ```
    Then open [http://localhost:3000/index.html](http://localhost:3000/index.html) in your browser.
 
-4. Ensure a MySQL server is running on `localhost:3306` with a database named
-   `blogpostapplication` and credentials `root`/`root`. If your database
-   configuration differs, update the values in
-   `src/main/resources/application.properties` accordingly.
+4. No external database setup is required. The application uses an embedded
+   H2 database that runs in memory. You can access the H2 console at
+   [http://localhost:8084/blogpostapplication/h2-console](http://localhost:8084/blogpostapplication/h2-console)
+   after starting the backend.
+
+### Running the Application 🚀
+
+1. From the project root, start the Spring Boot backend:
+   ```sh
+   ./mvnw spring-boot:run
+   ```
+   The API will be available at [http://localhost:8084/blogpostapplication](http://localhost:8084/blogpostapplication).
+   The first run may take a while as Maven downloads dependencies.
+
+   If you want to prefetch all dependencies manually, run:
+   ```sh
+   ./mvnw dependency:resolve
+   ```
+   This command uses the [maven-dependency-plugin](https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-dependency-plugin) to ensure all required artifacts are downloaded.
+
+2. *(Optional)* Execute the test suite:
+   ```sh
+   ./mvnw test
+   ```
 
 
 ### API Documentation
@@ -73,15 +96,9 @@ A simple blog application built with Spring Boot.
 After starting the Spring Boot application, you can explore all REST endpoints interactively using Swagger UI. Visit:
 
 ```
-
-http://localhost:8084/blogpostapplication/swagger-ui.html
-```
-
-Swagger resources are publicly accessible, so no authentication is required to browse the docs. The generated OpenAPI specification is also available at `/blogpostapplication/v3/api-docs` and can be used to generate client libraries.
-
 http://localhost:8084/blogpostapplication/swagger-ui/index.html
 ```
 
-The OpenAPI specification is also available at `/blogpostapplication/v3/api-docs` and can be used to generate client libraries.
+Swagger resources are publicly accessible, so no authentication is required to browse the docs. The generated OpenAPI specification is also available at `/blogpostapplication/v3/api-docs` and can be used to generate client libraries.
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,12 @@
 			<version>0.12.6</version>
 			<scope>runtime</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.mysql</groupId>
-			<artifactId>mysql-connector-j</artifactId>
-			<scope>runtime</scope>
-		</dependency>
+                <!-- Use H2 instead of MySQL for an embedded database -->
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,12 +3,15 @@ spring.application.name=blogapplication
 server.port=8084
 server.servlet.context-path=/blogpostapplication
 
-#database configuration
-spring.datasource.url=jdbc:mysql://localhost:3306/blogpostapplication
-spring.datasource.username=root
-spring.datasource.password=root
+# Database configuration (H2 in-memory)
+spring.datasource.url=jdbc:h2:mem:blogpostdb;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL8Dialect
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
 
 #spring boot security configuration
 #spring.security.user.name=user


### PR DESCRIPTION
## Summary
- replace MySQL dependency with H2
- update datasource settings to use embedded H2
- document H2 usage and console path in README

## Testing
- `npx -y babel frontend/app.js --out-file /tmp/app.out.js --presets=@babel/preset-react`
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6850009f05d0832fbfb995ae5ea25ec8